### PR TITLE
Add methods for 64-bit access

### DIFF
--- a/inc/udmaio/UioIf.hpp
+++ b/inc/udmaio/UioIf.hpp
@@ -56,8 +56,11 @@ class UioIf : private boost::noncopyable {
     mutable boost::log::sources::severity_logger_mt<blt::severity_level> _slg;
     bool _skip_write_to_arm_int;
 
-    volatile uint32_t* _reg_ptr(uint32_t offs) const {
+    volatile uint32_t* _reg_ptr32(uint32_t offs) const {
         return static_cast<volatile uint32_t*>(_mem) + offs / 4;
+    }
+    volatile uint64_t* _reg_ptr64(uint32_t offs) const {
+        return static_cast<volatile uint64_t*>(_mem) + offs / 8;
     }
 
     template <typename T>
@@ -67,7 +70,9 @@ class UioIf : private boost::noncopyable {
     }
 
     uint32_t _rd32(uint32_t offs) const;
+    uint64_t _rd64(uint32_t offs) const;
     void _wr32(uint32_t offs, uint32_t data);
+    void _wr64(uint32_t offs, uint64_t data);
 
     void arm_interrupt();
     uint32_t wait_for_interrupt();

--- a/src/UioIf.cpp
+++ b/src/UioIf.cpp
@@ -64,7 +64,14 @@ uint32_t UioIf::wait_for_interrupt() {
 }
 
 uint32_t UioIf::_rd32(uint32_t offs) const {
-    uint32_t tmp = *_reg_ptr(offs);
+    uint32_t tmp = *_reg_ptr32(offs);
+    BOOST_LOG_SEV(_slg, blt::severity_level::trace)
+        << _log_name() << ": read at 0x" << std::hex << offs << " = 0x" << tmp << std::dec;
+    return tmp;
+}
+
+uint64_t UioIf::_rd64(uint32_t offs) const {
+    uint64_t tmp = *_reg_ptr64(offs);
     BOOST_LOG_SEV(_slg, blt::severity_level::trace)
         << _log_name() << ": read at 0x" << std::hex << offs << " = 0x" << tmp << std::dec;
     return tmp;
@@ -73,7 +80,13 @@ uint32_t UioIf::_rd32(uint32_t offs) const {
 void UioIf::_wr32(uint32_t offs, uint32_t data) {
     BOOST_LOG_SEV(_slg, blt::severity_level::trace)
         << _log_name() << ": write at 0x" << std::hex << offs << " = 0x" << data << std::dec;
-    *_reg_ptr(offs) = data;
+    *_reg_ptr32(offs) = data;
+}
+
+void UioIf::_wr64(uint32_t offs, uint64_t data) {
+    BOOST_LOG_SEV(_slg, blt::severity_level::trace)
+        << _log_name() << ": write at 0x" << std::hex << offs << " = 0x" << data << std::dec;
+    *_reg_ptr64(offs) = data;
 }
 
 }  // namespace udmaio


### PR DESCRIPTION
This pull request adds two method (`_wr64` and `_rd64`) to allow generating 64-bit transactions (typically) on AXI bus. This can significantly improve performance (in some my measurements of up to 200%) for certain workloads.